### PR TITLE
Add target level to weapon upgrade path

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -1147,8 +1147,8 @@ function calculateCurrencyUpgrades() {
         const rarityColor = rarityColors[group.rarity.charAt(0).toUpperCase() + group.rarity.slice(1)];
         const tierUpper = group.tier.toUpperCase();
         const rarityFirstLetter = group.rarity.charAt(0).toUpperCase();
-
-        pathHTML += `<span style="color: ${rarityColor}; font-weight: 600;">${tierUpper} ${rarityFirstLetter} x${group.count}</span>`;
+        const weaponKey = `${group.rarity}-${group.tier}`;
+        pathHTML += `<span style="color: ${rarityColor}; font-weight: 600;">${tierUpper} ${rarityFirstLetter} x${group.count} (${weaponLevels[weaponKey]})</span>`;
 
         if (index < collatedUpgrades.length - 1) {
             pathHTML += ' <span style="color: var(--text-secondary);">,</span> ';


### PR DESCRIPTION
Removes some mental math to know when to 'stop' leveling a weapon
<img width="1170" height="541" alt="image" src="https://github.com/user-attachments/assets/eae915db-ed7d-46d3-80c7-9d0add43864d" />