### PR TITLE
Adjust 'normal' rarity color for light theme

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -61,8 +61,8 @@ const innerAbilityStats = [
 
 // Inner abilities data with min/max values per rarity
 const innerAbilitiesData = {
-	"Mystic": {
-		"Meso Drop": { "min": 9, "max": 15 },
+    "Mystic": {
+        "Meso Drop": { "min": 9, "max": 15 },
         "EXP Gain": { "min": 9, "max": 15 },
         "Defense Penetration": { "min": 14, "max": 20 },
         "Boss Monster Damage": { "min": 28, "max": 40 },
@@ -81,7 +81,7 @@ const innerAbilitiesData = {
         "Accuracy": { "min": 20, "max": 25 },
         "Evasion": { "min": 20, "max": 25 },
         "MP Recovery Per Sec": { "min": 80, "max": 150 }
-	},
+    },
     "Legendary": {
         "Meso Drop": { "min": 5, "max": 8 },
         "EXP Gain": { "min": 5, "max": 8 },
@@ -714,7 +714,7 @@ const rarityColors = {
     'Unique': '#ffd26d',
     'Epic': '#9966ff',
     'Rare': '#88bbff',
-    'Normal': '#ffffff',
+    'Normal': '#cccccc',
     'Mystic': '#ff3f42',
     'Ancient': '#2266cc'
 };


### PR DESCRIPTION
Before:
<img width="1517" height="515" alt="image" src="https://github.com/user-attachments/assets/a8bbaf6f-f529-4278-a292-57684111dae6" />
<img width="1545" height="493" alt="image" src="https://github.com/user-attachments/assets/ada2bb5b-c966-45f4-a571-238b5530dcdd" />


After:

<img width="1550" height="518" alt="image" src="https://github.com/user-attachments/assets/70792f3b-cf4b-4a55-8af1-64784a55479b" />
<img width="1557" height="505" alt="image" src="https://github.com/user-attachments/assets/b44c5d5b-4ee8-4410-93b0-1ad0d8d702ca" />
