### PR TITLE
Add button to apply upgrade path

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,12 @@
                             <div id="currency-upgrade-path" style="display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; font-size: 0.9em;">
                                 <!-- Path will be generated -->
                             </div>
+                            <div style="display: flex; justify-content: center; margin-top: 10px;">
+                                <button id="apply-upgrade-path-btn"
+                                    class="bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white px-4 py-2.5 rounded-lg cursor-pointer font-semibold text-sm shadow-md hover:shadow-lg transition-all">
+                                    Apply Upgrade Path
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/ui.js
+++ b/ui.js
@@ -1160,6 +1160,24 @@ function calculateCurrencyUpgrades() {
     dpsGainDisplay.textContent = `+${dpsGainPct.toFixed(2)}%`;
     pathDisplay.innerHTML = pathHTML;
     resultsDiv.style.display = 'block';
+    const applyUpgradesBtn = document.getElementById('apply-upgrade-path-btn');
+
+    // update weapon levels after user has leveled weps accordingly
+    applyUpgradesBtn.onclick = () => {
+        for (const key in weaponLevels) {
+            const levelInput = document.getElementById(`level-${key}`);
+            levelInput.value = weaponLevels[key];
+        }
+
+        // reset currency input
+        const currencyInput = document.getElementById('upgrade-currency-input');
+        currencyInput.value = '0';
+
+        // update/save stats
+        calculateCurrencyUpgrades();
+        saveToLocalStorage();
+        updateWeaponBonuses();
+    }
 }
 
 // Display functions


### PR DESCRIPTION
After clicking, sets all of the weapon level inputs to the displayed upgrade path, so that the user doesn't need to update their weapon levels manually. 

<img width="1186" height="512" alt="image" src="https://github.com/user-attachments/assets/aef070b8-8024-41d1-8e65-4e9fac0cf5c7" />
